### PR TITLE
Make conway updating considerably faster

### DIFF
--- a/conway.py
+++ b/conway.py
@@ -19,10 +19,7 @@ def conway(state, k=None):
     b = fft_convolve2d(state,k).round()
     c = np.zeros(b.shape)
 
-    c[np.where((b == 2) & (state == 1))] = 1
-    c[np.where((b == 3) & (state == 1))] = 1
-
-    c[np.where((b == 3) & (state == 0))] = 1
+    c[((b == 2) & (state == 1)) | (b == 3)] = 1
 
     # return new state
     return c


### PR DESCRIPTION
It is redundant to independently check if b is 3 and state is 1, and if so set c to 1, and check if b is 3 and state is 0, and if so set c to 1.
Fold these into one check.
Additionally, to reduce number of array lookups, fold the remaining two operations into one. using a bitwise or
Thirdly, in newer numpy versions numpy.where() is redundant, and slower than using the array[array condition] syntax